### PR TITLE
[FIX] Disable redirect slashes and remove trailing slashes from routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY ./app /usr/src/app
 # NB_API_PORT, representing the port on which the API will be exposed, 
 # is an environment variable that will always have a default value of 8000 when building the image
 # but can be overridden when running the container.
-ENTRYPOINT uvicorn app.main:app --proxy-headers --host 0.0.0.0 --port ${NB_API_PORT:-8000}
+ENTRYPOINT uvicorn app.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port ${NB_API_PORT:-8000}

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -103,7 +103,7 @@ async def get(
         params["image_modal"] = image_modal
 
     tasks = [
-        util.send_get_request(node_url + "query/", params)
+        util.send_get_request(node_url + "query", params)
         for node_url in node_urls
     ]
     responses = await asyncio.gather(*tasks, return_exceptions=True)

--- a/app/api/routers/nodes.py
+++ b/app/api/routers/nodes.py
@@ -5,7 +5,7 @@ from .. import utility as util
 router = APIRouter(prefix="/nodes", tags=["nodes"])
 
 
-@router.get("/")
+@router.get("")
 async def get_nodes():
     """Returns a dict of all available nodes apis where key is node URL and value is node name."""
     return [

--- a/app/api/routers/query.py
+++ b/app/api/routers/query.py
@@ -34,7 +34,7 @@ oauth2_scheme = OAuth2(
 # TODO: if our response model for fully successful vs. not fully successful responses grows more complex in the future,
 # consider additionally using https://fastapi.tiangolo.com/advanced/additional-responses/#additional-response-with-model to document
 # example responses for different status codes in the OpenAPI docs (less relevant for now since there is only one response model).
-@router.get("/", response_model=CombinedQueryResponse)
+@router.get("", response_model=CombinedQueryResponse)
 async def get_query(
     response: Response,
     query: QueryModel = Depends(QueryModel),

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ app = FastAPI(
     docs_url=None,
     redoc_url=None,
     lifespan=lifespan,
+    redirect_slashes=False,
 )
 
 app.add_middleware(

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ colorama==0.4.6
 coverage==7.0.0
 distlib==0.3.6
 exceptiongroup==1.0.4
-fastapi==0.95.2
+fastapi==0.110.1
 filelock==3.8.0
 google-auth==2.32.0
 h11==0.14.0
@@ -44,10 +44,10 @@ rpds-py==0.13.2
 rsa==4.9
 six==1.16.0
 sniffio==1.3.0
-starlette==0.27.0
+starlette==0.37.2
 toml==0.10.2
 tomli==2.0.1
-typing_extensions==4.4.0
+typing_extensions==4.12.2
 urllib3==2.2.0
 uvicorn==0.20.0
 virtualenv==20.16.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,3 +68,21 @@ def mock_failed_connection_httpx_get():
         raise httpx.ConnectError("Some connection error")
 
     return _mock_httpx_get_with_connect_error
+
+
+@pytest.fixture()
+def mocked_single_matching_dataset_result():
+    """Valid aggregate query result for a single matching dataset."""
+    return {
+        "dataset_uuid": "http://neurobagel.org/vocab/12345",
+        "dataset_name": "QPN",
+        "dataset_portal_uri": "https://rpq-qpn.ca/en/researchers-section/databases/",
+        "dataset_total_subjects": 200,
+        "num_matching_subjects": 5,
+        "records_protected": True,
+        "subject_data": "protected",
+        "image_modals": [
+            "http://purl.org/nidash/nidm#T1Weighted",
+            "http://purl.org/nidash/nidm#T2Weighted",
+        ],
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,13 @@ def test_app():
     yield client
 
 
-@pytest.fixture
+@pytest.fixture()
+def enable_auth(monkeypatch):
+    """Enable the authentication requirement for the API."""
+    monkeypatch.setattr("app.api.security.AUTH_ENABLED", True)
+
+
+@pytest.fixture()
 def disable_auth(monkeypatch):
     """
     Disable the authentication requirement for the API to skip startup checks

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -2,22 +2,6 @@ import httpx
 from fastapi import status
 
 
-def test_root(test_app, set_valid_test_federation_nodes):
-    """Given a GET request to the root endpoint, Check for 200 status and expected content."""
-
-    response = test_app.get("/")
-
-    assert response.status_code == status.HTTP_200_OK
-    assert all(
-        substring in response.text
-        for substring in [
-            "Welcome to",
-            "Neurobagel",
-            '<a href="/docs">documentation</a>',
-        ]
-    )
-
-
 def test_partially_failed_terms_fetching_handled_gracefully(
     test_app, monkeypatch, set_valid_test_federation_nodes, caplog
 ):

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -41,7 +41,7 @@ def test_nodes_discovery_endpoint(
     monkeypatch.setattr(httpx, "get", mock_httpx_get)
 
     with test_app:
-        response = test_app.get("/nodes/")
+        response = test_app.get("/nodes")
         assert util.FEDERATION_NODES == {
             "https://firstpublicnode.org/": "First Public Node",
             "https://secondpublicnode.org/": "Second Public Node",
@@ -77,7 +77,7 @@ def test_failed_public_nodes_fetching_raises_warning(
     monkeypatch.setattr(httpx, "get", mock_httpx_get)
 
     with test_app:
-        response = test_app.get("/nodes/")
+        response = test_app.get("/nodes")
         assert util.FEDERATION_NODES == {
             "https://mylocalnode.org/": "Local Node"
         }
@@ -123,7 +123,7 @@ def test_unset_local_nodes_raises_warning(test_app, monkeypatch, disable_auth):
 
     with pytest.warns(UserWarning) as w:
         with test_app:
-            response = test_app.get("/nodes/")
+            response = test_app.get("/nodes")
             assert util.FEDERATION_NODES == {
                 "https://firstpublicnode.org/": "First Public Node",
                 "https://secondpublicnode.org/": "Second Public Node",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -12,24 +12,6 @@ def mock_token():
     return "Bearer foo"
 
 
-@pytest.fixture()
-def mocked_single_matching_dataset_result():
-    """Valid aggregate query result for a single matching dataset."""
-    return {
-        "dataset_uuid": "http://neurobagel.org/vocab/12345",
-        "dataset_name": "QPN",
-        "dataset_portal_uri": "https://rpq-qpn.ca/en/researchers-section/databases/",
-        "dataset_total_subjects": 200,
-        "num_matching_subjects": 5,
-        "records_protected": True,
-        "subject_data": "protected",
-        "image_modals": [
-            "http://purl.org/nidash/nidm#T1Weighted",
-            "http://purl.org/nidash/nidm#T2Weighted",
-        ],
-    }
-
-
 def test_partial_node_failure_responses_handled_gracefully(
     monkeypatch,
     test_app,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -47,7 +47,7 @@ def test_partial_node_failure_responses_handled_gracefully(
     async def mock_httpx_get(self, **kwargs):
         # The self parameter is necessary to match the signature of the method being mocked,
         # which is a class method of the httpx.AsyncClient class (see https://www.python-httpx.org/api/#asyncclient).
-        if kwargs["url"] == "https://firstpublicnode.org/query/":
+        if kwargs["url"] == "https://firstpublicnode.org/query":
             return httpx.Response(
                 status_code=200, json=[mocked_single_matching_dataset_result]
             )
@@ -59,7 +59,7 @@ def test_partial_node_failure_responses_handled_gracefully(
     monkeypatch.setattr(httpx.AsyncClient, "get", mock_httpx_get)
 
     response = test_app.get(
-        "/query/",
+        "/query",
         headers={"Authorization": mock_token},
     )
 
@@ -127,7 +127,7 @@ def test_partial_node_request_failures_handled_gracefully(
     """
 
     async def mock_httpx_get(self, **kwargs):
-        if kwargs["url"] == "https://firstpublicnode.org/query/":
+        if kwargs["url"] == "https://firstpublicnode.org/query":
             return httpx.Response(
                 status_code=200, json=[mocked_single_matching_dataset_result]
             )
@@ -137,7 +137,7 @@ def test_partial_node_request_failures_handled_gracefully(
     monkeypatch.setattr(httpx.AsyncClient, "get", mock_httpx_get)
 
     response = test_app.get(
-        "/query/",
+        "/query",
         headers={"Authorization": mock_token},
     )
 
@@ -183,7 +183,7 @@ def test_all_nodes_failure_handled_gracefully(
     )
 
     response = test_app.get(
-        "/query/",
+        "/query",
         headers={"Authorization": mock_token},
     )
 
@@ -225,7 +225,7 @@ def test_all_nodes_success_handled_gracefully(
     monkeypatch.setattr(httpx.AsyncClient, "get", mock_httpx_get)
 
     response = test_app.get(
-        "/query/",
+        "/query",
         headers={"Authorization": mock_token},
     )
 
@@ -256,6 +256,6 @@ def test_query_without_token_succeeds_when_auth_disabled(
 
     monkeypatch.setattr(httpx.AsyncClient, "get", mock_httpx_get)
 
-    response = test_app.get("/query/")
+    response = test_app.get("/query")
 
     assert response.status_code == status.HTTP_200_OK

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,59 @@
+import httpx
+import pytest
+from fastapi import status
+
+
+def test_root(test_app, set_valid_test_federation_nodes):
+    """Given a GET request to the root endpoint, Check for 200 status and expected content."""
+
+    response = test_app.get("/")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert all(
+        substring in response.text
+        for substring in [
+            "Welcome to",
+            "Neurobagel",
+            '<a href="/docs">documentation</a>',
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "valid_route",
+    ["/query", "/query?min_age=20", "/nodes"],
+)
+def test_request_without_trailing_slash_not_redirected(
+    test_app,
+    monkeypatch,
+    set_valid_test_federation_nodes,
+    mocked_single_matching_dataset_result,
+    disable_auth,
+    valid_route,
+):
+    """Test that a request to the /query route is not redirected to have a trailing slash."""
+
+    async def mock_httpx_get(self, **kwargs):
+        return httpx.Response(
+            status_code=200, json=[mocked_single_matching_dataset_result]
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_httpx_get)
+
+    response = test_app.get(valid_route, follow_redirects=False)
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.parametrize(
+    "invalid_route",
+    ["/query/", "/query/?min_age=20", "/nodes/", "/attributes/nb:SomeClass/"],
+)
+def test_request_including_trailing_slash_fails(
+    test_app, disable_auth, invalid_route
+):
+    """
+    Test that a request to routes including a trailing slash, where none is expected,
+    is *not* redirected to exclude the slash, and fails with a 404.
+    """
+    response = test_app.get(invalid_route)
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -35,7 +35,7 @@ def test_request_without_trailing_slash_not_redirected(
     disable_auth,
     valid_route,
 ):
-    """Test that a request to the /query route is not redirected to have a trailing slash."""
+    """Test that a request to a route without a / is not redirected to have a trailing slash."""
 
     async def mock_httpx_get(self, **kwargs):
         return httpx.Response(
@@ -57,7 +57,7 @@ def test_request_including_trailing_slash_fails(
 ):
     """
     Test that a request to routes including a trailing slash, where none is expected,
-    is *not* redirected to exclude the slash, and fails with a 404.
+    is *not* redirected to exclude the slash, and returns a 404.
     """
     response = test_app.get(invalid_route)
     assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3,10 +3,14 @@ import pytest
 from fastapi import status
 
 
-def test_root(test_app, set_valid_test_federation_nodes):
+@pytest.mark.parametrize(
+    "root_path",
+    ["/", ""],
+)
+def test_root(test_app, set_valid_test_federation_nodes, root_path):
     """Given a GET request to the root endpoint, Check for 200 status and expected content."""
 
-    response = test_app.get("/")
+    response = test_app.get(root_path, follow_redirects=False)
 
     assert response.status_code == status.HTTP_200_OK
     assert all(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -5,14 +5,13 @@ from app.api.security import verify_token
 
 
 def test_missing_client_id_raises_error_when_auth_enabled(
-    monkeypatch, test_app
+    monkeypatch, test_app, enable_auth
 ):
     """Test that a missing client ID raises an error on startup when authentication is enabled."""
     # We're using what should be default values of CLIENT_ID and AUTH_ENABLED here
     # (if the corresponding environment variables are unset),
     # but we set the values explicitly here for clarity
     monkeypatch.setattr("app.api.security.CLIENT_ID", None)
-    monkeypatch.setattr("app.api.security.AUTH_ENABLED", True)
 
     with pytest.raises(ValueError) as exc_info:
         with test_app:
@@ -52,12 +51,20 @@ def test_invalid_token_raises_error(invalid_token):
     [{}, {"Authorization": ""}, {"badheader": "badvalue"}],
 )
 def test_query_with_malformed_auth_header_fails(
-    test_app, set_mock_verify_token, invalid_auth_header
+    test_app,
+    set_mock_verify_token,
+    enable_auth,
+    invalid_auth_header,
+    monkeypatch,
 ):
-    """Test that a request to the /query route with a missing or malformed authorization header, fails ."""
+    """
+    Test that when authentication is enabled, a request to the /query route with a
+    missing or malformed authorization header fails.
+    """
+    monkeypatch.setattr("app.api.security.CLIENT_ID", "foo.id")
 
     response = test_app.get(
-        "/query/",
+        "/query",
         headers=invalid_auth_header,
     )
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #108 
- Related to https://github.com/neurobagel/api/pull/328

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- FastAPI version update to allow disabling `redirect_slashes` globally (available since https://github.com/fastapi/fastapi/releases/tag/0.98.0)
- API will no longer redirect requests with or without a trailing slash to the version defined in the route decorator
- `/query`, `/nodes` routes no longer expect a slash at the end (or before query params)
- Minor fix of test context for tests requiring auth to be enabled 
- uvicorn command in Dockerfile updated to trust `X-Forwarded...` proxy headers from all remote IPs, to ensure we don't lose https from a request once behind a proxy

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
