### PR TITLE
[FIX] Allow only `"true"` or `None` for `is_control` query parameter

### DIFF
--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -37,7 +37,7 @@ async def get(
     max_age: float,
     sex: str,
     diagnosis: str,
-    is_control: bool,
+    is_control: str,
     min_num_imaging_sessions: int,
     min_num_phenotypic_sessions: int,
     assessment: str,
@@ -59,7 +59,7 @@ async def get(
         Sex of subject.
     diagnosis : str
         Subject diagnosis.
-    is_control : bool
+    is_control : str
         Whether or not subject is a control.
     min_num_imaging_sessions : int
         Subject minimum number of imaging sessions.

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -4,7 +4,8 @@ from enum import Enum
 from typing import Optional, Union
 
 from fastapi import Query
-from pydantic import BaseModel, Field
+from fastapi.exceptions import HTTPException
+from pydantic import BaseModel, Field, validator
 
 CONTROLLED_TERM_REGEX = r"^[a-zA-Z]+[:]\S+$"
 
@@ -16,7 +17,7 @@ class QueryModel(BaseModel):
     max_age: float = None
     sex: str = None
     diagnosis: str = None
-    is_control: bool = None
+    is_control: str = None
     min_num_imaging_sessions: int = None
     min_num_phenotypic_sessions: int = None
     assessment: str = None
@@ -26,6 +27,20 @@ class QueryModel(BaseModel):
     # TODO: Replace default value with union of local and public nodes once https://github.com/neurobagel/federation-api/issues/28 is merged
     # syntax from https://github.com/tiangolo/fastapi/issues/4445#issuecomment-1117632409
     node_url: list[str] | None = Field(Query(default=[]))
+
+    @validator("is_control")
+    def check_allowed_iscontrol_values(cls, v):
+        """Raise a validation error if the value of 'is_control' is not 'true' (case-insensitive) or None."""
+        if v is not None:
+            # Ensure that the allowed value is case-insensitive
+            if v.lower() != "true":
+                raise HTTPException(
+                    status_code=422,
+                    detail="'is_control' must be either set to 'true' or omitted from the query",
+                )
+            # Keep it a str because that's what the n-API expects
+            return v
+        return None
 
 
 class CohortQueryResponse(BaseModel):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,6 +4,9 @@ import logging
 import httpx
 import pytest
 from fastapi import status
+from fastapi.exceptions import HTTPException
+
+from app.api.models import QueryModel
 
 
 @pytest.fixture()
@@ -241,3 +244,21 @@ def test_query_without_token_succeeds_when_auth_disabled(
     response = test_app.get("/query")
 
     assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.parametrize("valid_iscontrol", ["true", "True", "TRUE"])
+def test_valid_iscontrol_values_unchanged(valid_iscontrol):
+    """Test that valid values for the 'is_control' field are accepted without modification or errors."""
+    example_fquery = QueryModel(is_control=valid_iscontrol)
+    assert example_fquery.is_control == valid_iscontrol
+
+
+@pytest.mark.parametrize("invalid_iscontrol", ["false", 52])
+def test_invalid_iscontrol_value_raises_error(invalid_iscontrol):
+    """Test that invalid values for the 'is_control' field fail model validation and raise an informative HTTPException."""
+    with pytest.raises(HTTPException) as exc:
+        QueryModel(is_control=invalid_iscontrol)
+
+    assert "'is_control' must be either set to 'true' or omitted" in str(
+        exc.value
+    )


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #128 
- Related to neurobagel/api#364

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- `is_control` query param now accepts str or `None`, with allowed str values being only "true" (case-insensitive) via custom validation
  - note: for the other query params we rely on the n-APIs to do the validation, but since this behaviour for `is_control` is a bit unintuitive, having basic validation in f-API may help to avoid confusion (for us and users)
- valid str values are passed on, as is, to n-APIs

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.
