### PR TITLE
[ENH] Make `root_path` for app configurable

### DIFF
--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -14,6 +14,9 @@ from jsonschema import validate
 
 EnvVar = namedtuple("EnvVar", ["name", "value"])
 
+ROOT_PATH = EnvVar(
+    "NB_FAPI_ROOT_PATH", os.environ.get("NB_FAPI_ROOT_PATH", "")
+)
 IS_FEDERATE_REMOTE_PUBLIC_NODES = EnvVar(
     "NB_FEDERATE_REMOTE_PUBLIC_NODES",
     os.environ.get("NB_FEDERATE_REMOTE_PUBLIC_NODES", "True").lower()

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ import logging
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.responses import HTMLResponse, ORJSONResponse, RedirectResponse
@@ -34,6 +34,7 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(
+    root_path=util.ROOT_PATH.value,
     default_response_class=ORJSONResponse,
     docs_url=None,
     redoc_url=None,
@@ -51,15 +52,15 @@ app.add_middleware(
 
 
 @app.get("/", response_class=HTMLResponse)
-def root():
+def root(request: Request):
     """
     Display a welcome message and a link to the API documentation.
     """
-    return """
+    return f"""
     <html>
         <body>
             <h1>Welcome to the Neurobagel Federation API!</h1>
-            <p>Please visit the <a href="/docs">documentation</a> to view available API endpoints.</p>
+            <p>Please visit the <a href="{request.scope.get("root_path", "")}/docs">API documentation</a> to view available API endpoints.</p>
         </body>
     </html>
     """
@@ -74,24 +75,24 @@ async def favicon():
 
 
 @app.get("/docs", include_in_schema=False)
-def overridden_swagger():
+def overridden_swagger(request: Request):
     """
     Overrides the Swagger UI HTML for the "/docs" endpoint.
     """
     return get_swagger_ui_html(
-        openapi_url="/openapi.json",
+        openapi_url=f"{request.scope.get('root_path', '')}/openapi.json",
         title="Neurobagel Federation API",
         swagger_favicon_url=favicon_url,
     )
 
 
 @app.get("/redoc", include_in_schema=False)
-def overridden_redoc():
+def overridden_redoc(request: Request):
     """
     Overrides the Redoc HTML for the "/redoc" endpoint.
     """
     return get_redoc_html(
-        openapi_url="/openapi.json",
+        openapi_url=f"{request.scope.get('root_path', '')}/openapi.json",
         title="Neurobagel Federation API",
         redoc_favicon_url=favicon_url,
     )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -19,8 +19,7 @@ def test_root(test_app, set_valid_test_federation_nodes, route, monkeypatch):
     assert all(
         substring in response.text
         for substring in [
-            "Welcome to",
-            "Neurobagel",
+            "Neurobagel Federation API",
             '<a href="/docs">API documentation</a>',
         ]
     )
@@ -84,6 +83,29 @@ def test_docs_work_using_defined_root_path(
     """
 
     monkeypatch.setattr(app, "root_path", "/fapi/v1")
+    docs_response = test_app.get(f"{test_route}/docs", follow_redirects=False)
+    schema_response = test_app.get(
+        f"{test_route}/openapi.json", follow_redirects=False
+    )
+    assert docs_response.status_code == expected_status_code
+    assert schema_response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "test_route,expected_status_code",
+    [("", 200), ("/fapi/", 200), ("/fapi", 404)],
+)
+def test_docs_when_root_path_includes_trailing_slash(
+    test_app, test_route, expected_status_code, monkeypatch
+):
+    """
+    Test that when the API root_path is set with a trailing slash, the interactive docs and OpenAPI schema are only reachable
+    using a path prefix with the extra trailing slash also included, or without the prefix entirely.
+
+    This provides a sanity check that the app does not ignore/redirect trailing slashes in the root_path when requests are received.
+    """
+
+    monkeypatch.setattr(app, "root_path", "/fapi/")
     docs_response = test_app.get(f"{test_route}/docs", follow_redirects=False)
     schema_response = test_app.get(
         f"{test_route}/openapi.json", follow_redirects=False


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #152 
- Related to: https://github.com/neurobagel/recipes/issues/102

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- The root path for the FastAPI app is now configurable via an optional environment variable `NB_FAPI_ROOT_PATH`
    - Meant for use in deployment scenarios with proxy servers that use a stripped path prefix

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enhancements:
- Allow the application to be deployed under a specific path, such as `/fapi/v1`.