### PR TITLE
 [MNT] Remove trailing slashes from all paths + rename `NB_FAPI_ROOT_PATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Federation API
 
-![GitHub branch check runs](https://img.shields.io/github/check-runs/neurobagel/federation-api/main?style=flat-square)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/neurobagel/federation-api/test.yaml?branch=main&style=flat-square&label=tests&link=https%3A%2F%2Fgithub.com%2Fneurobagel%2Ffederation-api%2Factions%2Fworkflows%2Ftest.yaml)
-![Codecov](https://img.shields.io/codecov/c/github/neurobagel/federation-api?token=B827PI9W1U&style=flat-square&logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Ffederation-api)
-![Static Badge](https://img.shields.io/badge/python-3.10-blue?style=flat-square&logo=python)
-![GitHub License](https://img.shields.io/github/license/neurobagel/federation-api?style=flat-square&color=purple&link=LICENSE)
-![Docker Image Version (tag)](https://img.shields.io/docker/v/neurobagel/federation_api/latest?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Ffederation_api%2Ftags)
-![Docker Pulls](https://img.shields.io/docker/pulls/neurobagel/federation_api?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Ffederation_api%2Ftags)
+[![Main branch check status](https://img.shields.io/github/check-runs/neurobagel/federation-api/main?style=flat-square)](https://github.com/neurobagel/federation-api/actions?query=branch:main)
+[![Tests status](https://img.shields.io/github/actions/workflow/status/neurobagel/federation-api/test.yaml?branch=main&style=flat-square&label=tests&link=https%3A%2F%2Fgithub.com%2Fneurobagel%2Ffederation-api%2Factions%2Fworkflows%2Ftest.yaml)](https://github.com/neurobagel/federation-api/actions/workflows/test.yaml)
+[![Codecov](https://img.shields.io/codecov/c/github/neurobagel/federation-api?token=B827PI9W1U&style=flat-square&logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Ffederation-api)](https://app.codecov.io/gh/neurobagel/federation-api)
+[![Python versions static](https://img.shields.io/badge/python-3.10-blue?style=flat-square&logo=python)](https://www.python.org)
+[![License](https://img.shields.io/github/license/neurobagel/federation-api?style=flat-square&color=purple&link=LICENSE)](LICENSE)
+[![Docker Image Version (tag)](https://img.shields.io/docker/v/neurobagel/federation_api/latest?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Ffederation_api%2Ftags)](https://hub.docker.com/r/neurobagel/federation_api/tags)
+[![Docker Pulls](https://img.shields.io/docker/pulls/neurobagel/federation_api?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Ffederation_api%2Ftags)](https://hub.docker.com/r/neurobagel/federation_api/tags)
 
 </div>
 

--- a/app/api/routers/assessments.py
+++ b/app/api/routers/assessments.py
@@ -6,7 +6,7 @@ from . import route_factory
 router = APIRouter(prefix="/assessments", tags=["assessments"])
 
 router.add_api_route(
-    path="/",
+    path="",
     endpoint=route_factory.create_get_instances_handler(
         attributes_base_path="assessments"
     ),

--- a/app/api/routers/diagnoses.py
+++ b/app/api/routers/diagnoses.py
@@ -6,7 +6,7 @@ from . import route_factory
 router = APIRouter(prefix="/diagnoses", tags=["diagnoses"])
 
 router.add_api_route(
-    path="/",
+    path="",
     endpoint=route_factory.create_get_instances_handler(
         attributes_base_path="diagnoses"
     ),

--- a/app/api/routers/pipelines.py
+++ b/app/api/routers/pipelines.py
@@ -8,7 +8,7 @@ from . import route_factory
 router = APIRouter(prefix="/pipelines", tags=["pipelines"])
 
 router.add_api_route(
-    path="/",
+    path="",
     endpoint=route_factory.create_get_instances_handler(
         attributes_base_path="pipelines"
     ),

--- a/app/api/routers/route_factory.py
+++ b/app/api/routers/route_factory.py
@@ -12,8 +12,8 @@ from .. import crud
 # (less relevant for now since there is only one response model).
 def create_get_instances_handler(attributes_base_path: str):
     """
-    Create the handler (path function) for a federated GET request to the root `/` subpath of
-    a given attribute router, e.g. /assesssments/.
+    Create the handler (path function) for a federated GET request to the base subpath of
+    a given attribute router, e.g. /assesssments.
     """
 
     async def get_instances(response: Response):

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -15,7 +15,7 @@ from jsonschema import validate
 EnvVar = namedtuple("EnvVar", ["name", "value"])
 
 ROOT_PATH = EnvVar(
-    "NB_FAPI_ROOT_PATH", os.environ.get("NB_FAPI_ROOT_PATH", "")
+    "NB_FAPI_BASE_PATH", os.environ.get("NB_FAPI_BASE_PATH", "")
 )
 IS_FEDERATE_REMOTE_PUBLIC_NODES = EnvVar(
     "NB_FEDERATE_REMOTE_PUBLIC_NODES",

--- a/tests/test_attribute_factory_routes.py
+++ b/tests/test_attribute_factory_routes.py
@@ -6,7 +6,7 @@ def test_get_instances_with_duplicate_terms_handled(
     test_app, monkeypatch, set_valid_test_federation_nodes
 ):
     """
-    When multiple nodes return an assessment with the same URI for a request to /assessments/,
+    When multiple nodes return an assessment with the same URI for a request to /assessments,
     the API should return only one instance of that assessment term in the final federated response.
     """
 
@@ -66,7 +66,7 @@ def test_partially_failed_get_instances_handled_gracefully(
     test_app, monkeypatch, set_valid_test_federation_nodes, caplog
 ):
     """
-    When some nodes fail while getting term instances for an attribute (/assessments/),
+    When some nodes fail while getting term instances for an attribute (/assessments),
     the overall API get request still succeeds, and the response includes a list of the encountered errors along with the successfully fetched terms.
     """
     mocked_node_get_assessments_response = {
@@ -120,7 +120,7 @@ def test_fully_failed_get_instances_handled_gracefully(
     caplog,
 ):
     """
-    When *all* nodes fail while getting term instances for an attribute (/assessments/),
+    When *all* nodes fail while getting term instances for an attribute (/assessments),
     the overall API get request still succeeds, but includes an overall failure status and all encountered errors in the response.
     """
     monkeypatch.setattr(

--- a/tests/test_attribute_factory_routes.py
+++ b/tests/test_attribute_factory_routes.py
@@ -42,7 +42,7 @@ def test_get_instances_with_duplicate_terms_handled(
 
     monkeypatch.setattr(httpx.AsyncClient, "get", mock_httpx_get)
 
-    response = test_app.get("/assessments/")
+    response = test_app.get("/assessments")
 
     response_object = response.json()
     found_instances = response_object["responses"]["nb:Assessment"]
@@ -94,7 +94,7 @@ def test_partially_failed_get_instances_handled_gracefully(
 
     monkeypatch.setattr(httpx.AsyncClient, "get", mock_httpx_get)
 
-    response = test_app.get("/assessments/")
+    response = test_app.get("/assessments")
 
     assert response.status_code == status.HTTP_207_MULTI_STATUS
 
@@ -127,7 +127,7 @@ def test_fully_failed_get_instances_handled_gracefully(
         httpx.AsyncClient, "get", mock_failed_connection_httpx_get
     )
 
-    response = test_app.get("/assessments/")
+    response = test_app.get("/assessments")
 
     assert response.status_code == status.HTTP_207_MULTI_STATUS
     # We expect several warnings from logging

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -52,7 +52,13 @@ def test_request_without_trailing_slash_not_redirected(
 
 @pytest.mark.parametrize(
     "invalid_route",
-    ["/query/", "/query/?min_age=20", "/nodes/", "/attributes/nb:SomeClass/"],
+    [
+        "/query/",
+        "/query/?min_age=20",
+        "/nodes/",
+        "/attributes/",
+        "/assessments/",
+    ],
 )
 def test_request_including_trailing_slash_fails(
     test_app, disable_auth, invalid_route


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #156 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Remove trailing slashes from all defined paths except the root, which requires the trailing slash in the path definition (but is indifferent to its inclusion)

Housekeeping:
- Rename `NB_FAPI_ROOT_PATH` -> `NB_FAPI_BASE_PATH` for consistency with other tools
- Fix README badge links

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Remove trailing slashes from all API paths and rename the NB_FAPI_ROOT_PATH environment variable to NB_FAPI_BASE_PATH.

Bug Fixes:
- Handle requests with trailing slashes correctly.

Chores:
- Rename `NB_FAPI_ROOT_PATH` to `NB_FAPI_BASE_PATH`.