### PR TITLE
[ENH] Support requests to catalog-mode nodes

### DIFF
--- a/app/api/models.py
+++ b/app/api/models.py
@@ -117,7 +117,7 @@ class CohortQueryResponse(SubjectsQueryResponse):
     dataset_portal_uri: str | None
     dataset_total_subjects: int
     records_protected: bool
-    num_matching_subjects: int | None
+    num_matching_subjects: int
     image_modals: list
     available_pipelines: dict
 

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -90,7 +90,7 @@ class DatasetsQueryResponse(BaseModel):
     access_link: str | None = None
     dataset_total_subjects: int
     records_protected: bool
-    num_matching_subjects: int
+    num_matching_subjects: int | None
     image_modals: list
     available_pipelines: dict
 
@@ -117,7 +117,7 @@ class CohortQueryResponse(SubjectsQueryResponse):
     dataset_portal_uri: str | None
     dataset_total_subjects: int
     records_protected: bool
-    num_matching_subjects: int
+    num_matching_subjects: int | None
     image_modals: list
     available_pipelines: dict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,8 +150,8 @@ def mocked_datasets_query_response_for_single_dataset():
 
 
 @pytest.fixture()
-def mocked_datasets_query_response_in_catalog_mode():
-    """Valid aggregate query response for a single matching dataset in catalog mode from a request to POST /datasets."""
+def mocked_datasets_query_response_for_single_dataset_from_catalog_node():
+    """Valid aggregate query response for a single matching dataset from a catalog node from a request to POST /datasets."""
     return {
         "dataset_uuid": "http://neurobagel.org/vocab/12345",
         "dataset_name": "QPN",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,3 +147,26 @@ def mocked_datasets_query_response_for_single_dataset():
             ],
         },
     }
+
+
+@pytest.fixture()
+def mocked_datasets_query_response_in_catalog_mode():
+    """Valid aggregate query response for a single matching dataset in catalog mode from a request to POST /datasets."""
+    return {
+        "dataset_uuid": "http://neurobagel.org/vocab/12345",
+        "dataset_name": "QPN",
+        "authors": ["First Author", "Second Author"],
+        "homepage": "https://rpq-qpn.ca/en/home/",
+        "references_and_links": [],
+        "keywords": ["Parkinson's disease", "Neuroimaging"],
+        "repository_url": None,
+        "access_instructions": None,
+        "access_type": "restricted",
+        "access_email": None,
+        "access_link": "https://rpq-qpn.ca/en/researchers-section/databases/",
+        "dataset_total_subjects": 200,
+        "num_matching_subjects": None,
+        "records_protected": True,
+        "image_modals": [],
+        "available_pipelines": {},
+    }

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,7 +5,7 @@ from fastapi import status
 ROUTE = "/datasets"
 
 
-@pytest.mark.parametrize("mock_response_type", ["single", "catalog"])
+@pytest.mark.parametrize("mock_node_type", ["subject-level", "catalog"])
 @pytest.mark.parametrize(
     "valid_nodes",
     [
@@ -24,7 +24,7 @@ def test_valid_nodes_query_does_not_error(
     mocked_datasets_query_response_for_single_dataset,
     mocked_datasets_query_response_in_catalog_mode,
     valid_nodes,
-    mock_response_type,
+    mock_node_type,
     monkeypatch,
     caplog,
 ):
@@ -33,7 +33,7 @@ def test_valid_nodes_query_does_not_error(
     """
 
     async def mock_httpx_request(self, method, url, **kwargs):
-        if mock_response_type == "single":
+        if mock_node_type == "subject-level":
             return httpx.Response(
                 status_code=200,
                 json=[mocked_datasets_query_response_for_single_dataset],
@@ -107,7 +107,7 @@ def test_valid_nodes_query_returns_only_dataset_metadata(
         None,
     ],
 )
-def test_valid_nodes_query_returns_only_dataset_metadata_in_catalog_mode(
+def test_valid_nodes_query_returns_only_catalog_metadata_from_catalog_nodes(
     test_app,
     disable_auth,
     set_valid_test_federation_nodes,
@@ -116,8 +116,8 @@ def test_valid_nodes_query_returns_only_dataset_metadata_in_catalog_mode(
     monkeypatch,
 ):
     """
-    Test that when a valid 'nodes' list is provided, the POST /datasets response includes expected
-    dataset-level metadata fields and no subject, imaging, or derivative data in catalog mode.
+    Test that when a valid 'nodes' list is provided and all known nodes are in catalog mode, the POST /datasets response includes expected
+    dataset-level metadata fields and no subject, imaging, or derivative data.
     """
 
     async def mock_httpx_request(self, method, url, **kwargs):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,6 +5,7 @@ from fastapi import status
 ROUTE = "/datasets"
 
 
+@pytest.mark.parametrize("mock_response_type", ["single", "catalog"])
 @pytest.mark.parametrize(
     "valid_nodes",
     [
@@ -21,7 +22,9 @@ def test_valid_nodes_query_does_not_error(
     disable_auth,
     set_valid_test_federation_nodes,
     mocked_datasets_query_response_for_single_dataset,
+    mocked_datasets_query_response_in_catalog_mode,
     valid_nodes,
+    mock_response_type,
     monkeypatch,
     caplog,
 ):
@@ -30,9 +33,14 @@ def test_valid_nodes_query_does_not_error(
     """
 
     async def mock_httpx_request(self, method, url, **kwargs):
+        if mock_response_type == "single":
+            return httpx.Response(
+                status_code=200,
+                json=[mocked_datasets_query_response_for_single_dataset],
+            )
         return httpx.Response(
             status_code=200,
-            json=[mocked_datasets_query_response_for_single_dataset],
+            json=[mocked_datasets_query_response_in_catalog_mode],
         )
 
     monkeypatch.setattr(httpx.AsyncClient, "request", mock_httpx_request)
@@ -86,6 +94,50 @@ def test_valid_nodes_query_returns_only_dataset_metadata(
         assert "subject_data" not in response
         assert "dataset_name" in response
         assert "access_type" in response
+
+
+@pytest.mark.parametrize(
+    "valid_nodes",
+    [
+        [
+            {"node_url": "https://firstpublicnode.org/"},
+            {"node_url": "https://secondpublicnode.org/"},
+        ],
+        [],
+        None,
+    ],
+)
+def test_valid_nodes_query_returns_only_dataset_metadata_in_catalog_mode(
+    test_app,
+    disable_auth,
+    set_valid_test_federation_nodes,
+    mocked_datasets_query_response_in_catalog_mode,
+    valid_nodes,
+    monkeypatch,
+):
+    """
+    Test that when a valid 'nodes' list is provided, the POST /datasets response includes expected
+    dataset-level metadata fields and no subject, imaging, or derivative data in catalog mode.
+    """
+
+    async def mock_httpx_request(self, method, url, **kwargs):
+        return httpx.Response(
+            status_code=200,
+            json=[mocked_datasets_query_response_in_catalog_mode],
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", mock_httpx_request)
+
+    response = test_app.post(ROUTE, json={"nodes": valid_nodes})
+
+    response = response.json()
+    for response in response["responses"]:
+        assert "subject_data" not in response
+        assert "dataset_name" in response
+        assert "access_type" in response
+        assert response.get("num_matching_subjects") is None
+        assert response.get("image_modals") == []
+        assert response.get("available_pipelines") == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -22,7 +22,7 @@ def test_valid_nodes_query_does_not_error(
     disable_auth,
     set_valid_test_federation_nodes,
     mocked_datasets_query_response_for_single_dataset,
-    mocked_datasets_query_response_in_catalog_mode,
+    mocked_datasets_query_response_for_single_dataset_from_catalog_node,
     valid_nodes,
     mock_node_type,
     monkeypatch,
@@ -40,7 +40,9 @@ def test_valid_nodes_query_does_not_error(
             )
         return httpx.Response(
             status_code=200,
-            json=[mocked_datasets_query_response_in_catalog_mode],
+            json=[
+                mocked_datasets_query_response_for_single_dataset_from_catalog_node
+            ],
         )
 
     monkeypatch.setattr(httpx.AsyncClient, "request", mock_httpx_request)
@@ -111,7 +113,7 @@ def test_valid_nodes_query_returns_only_catalog_metadata_from_catalog_nodes(
     test_app,
     disable_auth,
     set_valid_test_federation_nodes,
-    mocked_datasets_query_response_in_catalog_mode,
+    mocked_datasets_query_response_for_single_dataset_from_catalog_node,
     valid_nodes,
     monkeypatch,
 ):
@@ -123,7 +125,9 @@ def test_valid_nodes_query_returns_only_catalog_metadata_from_catalog_nodes(
     async def mock_httpx_request(self, method, url, **kwargs):
         return httpx.Response(
             status_code=200,
-            json=[mocked_datasets_query_response_in_catalog_mode],
+            json=[
+                mocked_datasets_query_response_for_single_dataset_from_catalog_node
+            ],
         )
 
     monkeypatch.setattr(httpx.AsyncClient, "request", mock_httpx_request)


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #248

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Update data models to allow for `None` in `num_matching_subjects` field
- Added and updated tests to cover catalog mode response from nodes

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Support catalog-mode dataset queries by allowing nullable subject counts and ensuring responses contain only high-level dataset metadata.

New Features:
- Add support for catalog-mode dataset query responses from federation nodes.

Enhancements:
- Relax query response models to allow num_matching_subjects to be null when only aggregate dataset metadata is returned.

Tests:
- Extend dataset query tests to cover both single-dataset and catalog-mode responses and validate that catalog-mode responses exclude subject-level and imaging data.